### PR TITLE
Update ethereumjs-tx dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "bignumber.js": "^2.0.7",
     "browserify-cryptojs": "^0.3.1",
-    "ethereumjs-tx": "^0.4.0",
+    "ethereumjs-tx": "^0.7.2",
     "jszip": "^2.5.0",
     "localstorejs": "^0.1.9",
     "node-safe-filesaver": "^0.1.0",


### PR DESCRIPTION
Was getting this error running on node v4.2.6 - 

``````
CXX(target) Release/obj.target/secp256k1/secp256k1.o
In file included from ../secp256k1.cc:1:
../node_modules/nan/nan.h:324:27: error: redefinition of 'NanEnsureHandleOrPersistent'
  NAN_INLINE v8::Local<T> NanEnsureHandleOrPersistent(const v8::Local<T> &val) {
                          ^
../node_modules/nan/nan.h:319:17: note: previous definition is here
  v8::Handle<T> NanEnsureHandleOrPersistent(const v8::Handle<T> &val) {
                ^
../node_modules/nan/nan.h:344:27: error: redefinition of 'NanEnsureLocal'
  NAN_INLINE v8::Local<T> NanEnsureLocal(const v8::Handle<T> &val) {
                          ^
../node_modules/nan/nan.h:334:27: note: previous definition is here
  NAN_INLINE v8::Local<T> NanEnsureLocal(const v8::Local<T> &val) {
                          ^
../node_modules/nan/nan.h:757:13: error: no member named 'smalloc' in namespace 'node'
    , node::smalloc::FreeCallback callback
      ~~~~~~^
../node_modules/nan/nan.h:768:12: error: no matching function for call to 'New'
    return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
           ^~~~~~~~~~~~~~~~~
/Users/gtaylor/.node-gyp/4.2.6/include/node/node_buffer.h:31:40: note: candidate function not viable: no known conversion from 'uint32_t' (aka 'unsigned int')
      to 'enum encoding' for 3rd argument
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/gtaylor/.node-gyp/4.2.6/include/node/node_buffer.h:43:40: note: candidate function not viable: 2nd argument ('const char *') would lose const qualifier
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/gtaylor/.node-gyp/4.2.6/include/node/node_buffer.h:28:40: note: candidate function not viable: requires 2 arguments, but 3 were provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate, size_t length);
                                       ^
/Users/gtaylor/.node-gyp/4.2.6/include/node/node_buffer.h:36:40: note: candidate function not viable: requires 5 arguments, but 3 were provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
In file included from ../secp256k1.cc:1:
../node_modules/nan/nan.h:772:12: error: no viable conversion from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object>'
    return node::Buffer::New(v8::Isolate::GetCurrent(), size);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/gtaylor/.node-gyp/4.2.6/include/node/v8.h:210:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from
      'v8::MaybeLocal<v8::Object>' to 'const v8::Local<v8::Object> &' for 1st argument
class Local {
      ^
/Users/gtaylor/.node-gyp/4.2.6/include/node/v8.h:210:7: note: candidate constructor (the implicit move constructor) not viable: no known conversion from
      'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object> &&' for 1st argument
class Local {
      ^
/Users/gtaylor/.node-gyp/4.2.6/include/node/v8.h:214:13: note: candidate template ignored: could not match 'Local' against 'MaybeLocal'
  V8_INLINE Local(Local<S> that)
            ^
/Users/gtaylor/.node-gyp/4.2.6/include/node/v8.h:326:13: note: candidate template ignored: could not match 'S *' against 'v8::MaybeLocal<v8::Object>'
  V8_INLINE Local(S* that)
            ^
In file included from ../secp256k1.cc:1:
../node_modules/nan/nan.h:779:26: error: no member named 'Use' in namespace 'node::Buffer'
    return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
           ~~~~~~~~~~~~~~^
In file included from ../secp256k1.cc:1:```

Upgrading ethereumjs-tx makes that go away.

``````
