### PR TITLE
Update ethereumjs-tx to fix broken secp256k1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "bignumber.js": "^2.0.7",
     "browserify-cryptojs": "^0.3.1",
-    "ethereumjs-tx": "^0.7.2",
+    "ethereumjs-tx": "^1.1.1",
     "jszip": "^2.5.0",
     "localstorejs": "^0.1.9",
     "node-safe-filesaver": "^0.1.0",


### PR DESCRIPTION
old version of ethereumjs-tx was ultimately referencing (within the old version of ethereumjs-utils) secp256k1@0.0.15 Which wasn't building on OSX or Ubuntu latest
 Now we are getting secp256k1@3.1.0 
